### PR TITLE
fix(backend): align issue 3 API with typespec

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -82,7 +82,7 @@ func main() {
 		api.DELETE("/event-types/:id", eventTypeHandler.Delete)
 
 		// Slot generation
-		api.POST("/slots/generate", timeSlotHandler.GenerateSlots)
+		api.POST("/event-types/:eventTypeId/slots/generate", timeSlotHandler.GenerateSlots)
 
 		// Slots
 		api.GET("/slots", timeSlotHandler.List)

--- a/backend/internal/handlers/booking_handler.go
+++ b/backend/internal/handlers/booking_handler.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"net/http"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/ProfMalina/ai-for-developers-project-386/backend/internal/repositories"
 	"github.com/ProfMalina/ai-for-developers-project-386/backend/internal/services"
@@ -29,15 +31,30 @@ func NewBookingHandler() *BookingHandler {
 func (h *BookingHandler) List(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "20"))
-	sortBy := c.DefaultQuery("sortBy", "created_at")
-	sortOrder := c.DefaultQuery("sortOrder", "desc")
+	sortBy := c.DefaultQuery("sortBy", "startTime")
+	sortOrder := c.DefaultQuery("sortOrder", "asc")
 
-	var status *string
-	if s := c.Query("status"); s != "" {
-		status = &s
+	var dateFrom *time.Time
+	if raw := c.Query("dateFrom"); raw != "" {
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			BadRequest(c, "dateFrom must be RFC3339")
+			return
+		}
+		dateFrom = &parsed
 	}
 
-	result, err := h.service.List(c.Request.Context(), page, pageSize, sortBy, sortOrder, status)
+	var dateTo *time.Time
+	if raw := c.Query("dateTo"); raw != "" {
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			BadRequest(c, "dateTo must be RFC3339")
+			return
+		}
+		dateTo = &parsed
+	}
+
+	result, err := h.service.List(c.Request.Context(), page, pageSize, sortBy, sortOrder, dateFrom, dateTo)
 	if err != nil {
 		BadRequest(c, "Failed to list bookings: "+err.Error())
 		return
@@ -65,6 +82,10 @@ func (h *BookingHandler) Cancel(c *gin.Context) {
 
 	err := h.service.Cancel(c.Request.Context(), id)
 	if err != nil {
+		if strings.Contains(err.Error(), "already cancelled") {
+			BadRequest(c, err.Error())
+			return
+		}
 		NotFound(c, "Booking")
 		return
 	}

--- a/backend/internal/handlers/helpers.go
+++ b/backend/internal/handlers/helpers.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/ProfMalina/ai-for-developers-project-386/backend/internal/models"
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
 )
 
 // SuccessResponse sends a successful JSON response
@@ -24,7 +27,7 @@ func ErrorResponse(c *gin.Context, status int, errorType, message string) {
 func ValidationError(c *gin.Context, fieldErrors []models.FieldError) {
 	c.JSON(http.StatusBadRequest, models.ErrorResponse{
 		Error:       "VALIDATION_ERROR",
-		Message:     "Validation failed",
+		Message:     "Request validation failed",
 		FieldErrors: fieldErrors,
 	})
 }
@@ -39,6 +42,11 @@ func BadRequest(c *gin.Context, message string) {
 	ErrorResponse(c, http.StatusBadRequest, "BAD_REQUEST", message)
 }
 
+// InvalidTime sends a 400 invalid time response
+func InvalidTime(c *gin.Context, message string) {
+	ErrorResponse(c, http.StatusBadRequest, "INVALID_TIME", message)
+}
+
 // Conflict sends a 409 error response
 func Conflict(c *gin.Context, message string) {
 	ErrorResponse(c, http.StatusConflict, "CONFLICT", message)
@@ -47,4 +55,36 @@ func Conflict(c *gin.Context, message string) {
 // NoContent sends a 204 response
 func NoContent(c *gin.Context) {
 	c.Status(http.StatusNoContent)
+}
+
+func errorAsValidation(err error, target *validator.ValidationErrors) bool {
+	return errors.As(err, target)
+}
+
+func lowerFirst(value string) string {
+	if value == "" {
+		return value
+	}
+	return strings.ToLower(value[:1]) + value[1:]
+}
+
+func validationMessage(fieldErr validator.FieldError) string {
+	switch fieldErr.Tag() {
+	case "required":
+		return "is required"
+	case "email":
+		return "must be a valid email"
+	case "uuid":
+		return "must be a valid UUID"
+	case "min":
+		return "is below the minimum value"
+	case "max":
+		return "exceeds the maximum value"
+	case "datetime":
+		return "must match the required datetime format"
+	case "oneof":
+		return "must be one of the allowed values"
+	default:
+		return "is invalid"
+	}
 }

--- a/backend/internal/handlers/public_booking_handler.go
+++ b/backend/internal/handlers/public_booking_handler.go
@@ -2,11 +2,13 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/ProfMalina/ai-for-developers-project-386/backend/internal/models"
 	"github.com/ProfMalina/ai-for-developers-project-386/backend/internal/repositories"
 	"github.com/ProfMalina/ai-for-developers-project-386/backend/internal/services"
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
 )
 
 // PublicBookingHandler handles HTTP requests for public bookings
@@ -29,6 +31,21 @@ func NewPublicBookingHandler() *PublicBookingHandler {
 func (h *PublicBookingHandler) Create(c *gin.Context) {
 	var req models.CreateBookingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		var validationErrors validator.ValidationErrors
+		if errorsAs := validator.ValidationErrors(nil); strings.Contains(err.Error(), "validation") || strings.Contains(err.Error(), "Field validation") {
+			_ = errorsAs
+		}
+		if ok := errorAsValidation(err, &validationErrors); ok {
+			fieldErrors := make([]models.FieldError, 0, len(validationErrors))
+			for _, fieldErr := range validationErrors {
+				fieldErrors = append(fieldErrors, models.FieldError{
+					Field:   lowerFirst(fieldErr.Field()),
+					Message: validationMessage(fieldErr),
+				})
+			}
+			ValidationError(c, fieldErrors)
+			return
+		}
 		BadRequest(c, "Invalid request body: "+err.Error())
 		return
 	}
@@ -56,9 +73,21 @@ func (h *PublicBookingHandler) Create(c *gin.Context) {
 
 	booking, err := h.service.Create(c.Request.Context(), req)
 	if err != nil {
-		// Check for conflict error
-		if err.Error() == "selected time slot is already booked" {
+		errText := err.Error()
+		if strings.Contains(errText, "selected time slot is already booked") || strings.Contains(errText, "already booked") || strings.Contains(errText, "overlap") {
 			Conflict(c, "Selected time slot is already booked")
+			return
+		}
+		if strings.Contains(errText, "event type not found") {
+			NotFound(c, "Event type")
+			return
+		}
+		if strings.Contains(errText, "time slot not found") {
+			NotFound(c, "Time slot")
+			return
+		}
+		if strings.Contains(errText, "already started or passed") {
+			InvalidTime(c, "Cannot book a slot that has already started or ended")
 			return
 		}
 		BadRequest(c, "Failed to create booking: "+err.Error())

--- a/backend/internal/handlers/public_event_type_handler.go
+++ b/backend/internal/handlers/public_event_type_handler.go
@@ -25,6 +25,7 @@ func NewPublicEventTypeHandler() *PublicEventTypeHandler {
 			repositories.NewTimeSlotRepository(),
 			repositories.NewSlotGenerationConfigRepository(),
 			repositories.NewOwnerRepository(),
+			repositories.NewEventTypeRepository(),
 		),
 	}
 }

--- a/backend/internal/handlers/time_slot_handler.go
+++ b/backend/internal/handlers/time_slot_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ProfMalina/ai-for-developers-project-386/backend/internal/db"
@@ -24,6 +25,7 @@ func NewTimeSlotHandler() *TimeSlotHandler {
 			repositories.NewTimeSlotRepository(),
 			repositories.NewSlotGenerationConfigRepository(),
 			repositories.NewOwnerRepository(),
+			repositories.NewEventTypeRepository(),
 		),
 	}
 }
@@ -39,13 +41,23 @@ func (h *TimeSlotHandler) List(c *gin.Context) {
 	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "20"))
 
 	var available *bool
-	if availStr := c.Query("available"); availStr != "" {
+	if availStr := c.Query("isAvailable"); availStr != "" {
+		avail := availStr == "true"
+		available = &avail
+	} else if availStr := c.Query("available"); availStr != "" {
 		avail := availStr == "true"
 		available = &avail
 	}
 
 	var startTime *time.Time
-	if startStr := c.Query("startTime"); startStr != "" {
+	if startStr := c.Query("dateFrom"); startStr != "" {
+		t, err := time.Parse(time.RFC3339, startStr)
+		if err != nil {
+			BadRequest(c, "dateFrom must be RFC3339")
+			return
+		}
+		startTime = &t
+	} else if startStr := c.Query("startTime"); startStr != "" {
 		t, err := time.Parse(time.RFC3339, startStr)
 		if err == nil {
 			startTime = &t
@@ -53,15 +65,28 @@ func (h *TimeSlotHandler) List(c *gin.Context) {
 	}
 
 	var endTime *time.Time
-	if endStr := c.Query("endTime"); endStr != "" {
+	if endStr := c.Query("dateTo"); endStr != "" {
+		t, err := time.Parse(time.RFC3339, endStr)
+		if err != nil {
+			BadRequest(c, "dateTo must be RFC3339")
+			return
+		}
+		endTime = &t
+	} else if endStr := c.Query("endTime"); endStr != "" {
 		t, err := time.Parse(time.RFC3339, endStr)
 		if err == nil {
 			endTime = &t
 		}
 	}
 
-	result, err := h.service.List(c.Request.Context(), ownerID, page, pageSize, available, startTime, endTime)
+	eventTypeID := strings.TrimSpace(c.Query("eventTypeId"))
+
+	result, err := h.service.List(c.Request.Context(), ownerID, eventTypeID, page, pageSize, available, startTime, endTime)
 	if err != nil {
+		if strings.Contains(err.Error(), "event type not found") {
+			NotFound(c, "Event type")
+			return
+		}
 		BadRequest(c, "Failed to list time slots: "+err.Error())
 		return
 	}
@@ -69,11 +94,16 @@ func (h *TimeSlotHandler) List(c *gin.Context) {
 	SuccessResponse(c, http.StatusOK, result)
 }
 
-// GenerateSlots handles POST /api/slots/generate
+// GenerateSlots handles POST /api/event-types/{eventTypeId}/slots/generate
 func (h *TimeSlotHandler) GenerateSlots(c *gin.Context) {
 	ownerID := c.GetString("ownerID")
 	if ownerID == "" {
 		ownerID = db.DefaultOwnerID
+	}
+	eventTypeID := strings.TrimSpace(c.Param("eventTypeId"))
+	if eventTypeID == "" {
+		BadRequest(c, "eventTypeId is required")
+		return
 	}
 
 	var req models.SlotGenerationRequest
@@ -82,14 +112,24 @@ func (h *TimeSlotHandler) GenerateSlots(c *gin.Context) {
 		return
 	}
 
-	// Validate days of week
-	if len(req.DaysOfWeek) < 1 || len(req.DaysOfWeek) > 7 {
+	// Validate days of week when provided
+	if len(req.DaysOfWeek) > 7 {
 		BadRequest(c, "days_of_week must contain 1-7 items")
 		return
 	}
+	for _, day := range req.DaysOfWeek {
+		if day < 0 || day > 6 {
+			BadRequest(c, "daysOfWeek values must be between 0 and 6")
+			return
+		}
+	}
 
-	result, err := h.service.GenerateSlots(c.Request.Context(), ownerID, req)
+	result, err := h.service.GenerateSlots(c.Request.Context(), ownerID, eventTypeID, req)
 	if err != nil {
+		if strings.Contains(err.Error(), "event type not found") {
+			NotFound(c, "Event type")
+			return
+		}
 		BadRequest(c, "Failed to generate slots: "+err.Error())
 		return
 	}

--- a/backend/internal/models/time_slot.go
+++ b/backend/internal/models/time_slot.go
@@ -6,6 +6,7 @@ import "time"
 type TimeSlot struct {
 	ID          string    `json:"id"`
 	OwnerID     string    `json:"ownerId"`
+	EventTypeID string    `json:"eventTypeId,omitempty"`
 	StartTime   time.Time `json:"startTime"`
 	EndTime     time.Time `json:"endTime"`
 	IsAvailable bool      `json:"isAvailable"`
@@ -38,8 +39,8 @@ type SlotGenerationConfig struct {
 type SlotGenerationRequest struct {
 	WorkingHoursStart string  `json:"workingHoursStart" binding:"required,datetime=15:04"`
 	WorkingHoursEnd   string  `json:"workingHoursEnd" binding:"required,datetime=15:04"`
-	IntervalMinutes   int     `json:"intervalMinutes" binding:"required,oneof=15 30"`
-	DaysOfWeek        []int   `json:"daysOfWeek" binding:"required"`
+	IntervalMinutes   int     `json:"intervalMinutes" binding:"omitempty,oneof=15 30"`
+	DaysOfWeek        []int   `json:"daysOfWeek" binding:"omitempty"`
 	DateFrom          string  `json:"dateFrom" binding:"omitempty,datetime=2006-01-02"`
 	DateTo            string  `json:"dateTo" binding:"omitempty,datetime=2006-01-02"`
 	Timezone          *string `json:"timezone,omitempty"`
@@ -47,6 +48,8 @@ type SlotGenerationRequest struct {
 
 // SlotGenerationResult represents the response from slot generation
 type SlotGenerationResult struct {
-	SlotsCreated   int      `json:"slotsCreated"`
-	CreatedSlotIDs []string `json:"createdSlotIds"`
+	SlotsCreated int    `json:"slotsCreated"`
+	SlotsSkipped int    `json:"slotsSkipped"`
+	DateFrom     string `json:"dateFrom"`
+	DateTo       string `json:"dateTo"`
 }

--- a/backend/internal/repositories/booking_repository.go
+++ b/backend/internal/repositories/booking_repository.go
@@ -71,22 +71,37 @@ func (r *BookingRepository) GetByID(ctx context.Context, id string) (*models.Boo
 }
 
 // List retrieves a paginated list of bookings with filters and sorting
-func (r *BookingRepository) List(ctx context.Context, page, pageSize int, sortBy, sortOrder string, status *string) ([]models.Booking, int, error) {
+func (r *BookingRepository) List(ctx context.Context, page, pageSize int, sortBy, sortOrder string, dateFrom, dateTo *time.Time) ([]models.Booking, int, error) {
 	if sortBy == "" {
-		sortBy = "created_at"
+		sortBy = "start_time"
 	}
 	if sortOrder == "" {
-		sortOrder = "desc"
+		sortOrder = "asc"
 	}
 
 	allowedSortFields := map[string]bool{
-		"created_at": true, "start_time": true, "guest_name": true, "status": true,
+		"created_at": true,
+		"createdAt":  true,
+		"start_time": true,
+		"startTime":  true,
+		"guest_name": true,
+		"guestName":  true,
+		"status":     true,
 	}
 	if !allowedSortFields[sortBy] {
-		sortBy = "created_at"
+		sortBy = "start_time"
 	}
 	if sortOrder != "asc" && sortOrder != "desc" {
-		sortOrder = "desc"
+		sortOrder = "asc"
+	}
+
+	sortFieldMap := map[string]string{
+		"createdAt": "created_at",
+		"startTime": "start_time",
+		"guestName": "guest_name",
+	}
+	if mapped, ok := sortFieldMap[sortBy]; ok {
+		sortBy = mapped
 	}
 
 	offset := (page - 1) * pageSize
@@ -96,10 +111,17 @@ func (r *BookingRepository) List(ctx context.Context, page, pageSize int, sortBy
 	args := []interface{}{}
 	argIdx := 1
 
-	if status != nil {
-		query += fmt.Sprintf(" AND status = $%d", argIdx)
-		countQuery += fmt.Sprintf(" AND status = $%d", argIdx)
-		args = append(args, *status)
+	if dateFrom != nil {
+		query += fmt.Sprintf(" AND start_time >= $%d", argIdx)
+		countQuery += fmt.Sprintf(" AND start_time >= $%d", argIdx)
+		args = append(args, *dateFrom)
+		argIdx++
+	}
+
+	if dateTo != nil {
+		query += fmt.Sprintf(" AND end_time <= $%d", argIdx)
+		countQuery += fmt.Sprintf(" AND end_time <= $%d", argIdx)
+		args = append(args, *dateTo)
 		argIdx++
 	}
 

--- a/backend/internal/repositories/time_slot_repository.go
+++ b/backend/internal/repositories/time_slot_repository.go
@@ -23,8 +23,8 @@ func NewTimeSlotRepository() *TimeSlotRepository {
 // Create creates a new time slot
 func (r *TimeSlotRepository) Create(ctx context.Context, slot *models.TimeSlot) error {
 	query := `
-		INSERT INTO time_slots (id, owner_id, start_time, end_time, is_available, created_at)
-		VALUES ($1, $2, $3, $4, $5, NOW())
+		INSERT INTO time_slots (id, owner_id, event_type_id, start_time, end_time, is_available, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, NOW())
 		RETURNING id, created_at
 	`
 
@@ -32,7 +32,7 @@ func (r *TimeSlotRepository) Create(ctx context.Context, slot *models.TimeSlot) 
 		slot.ID = uuid.New().String()
 	}
 
-	err := db.Pool.QueryRow(ctx, query, slot.ID, slot.OwnerID, slot.StartTime, slot.EndTime, slot.IsAvailable).
+	err := db.Pool.QueryRow(ctx, query, slot.ID, slot.OwnerID, slot.EventTypeID, slot.StartTime, slot.EndTime, slot.IsAvailable).
 		Scan(&slot.ID, &slot.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("failed to create time slot: %w", err)
@@ -43,11 +43,11 @@ func (r *TimeSlotRepository) Create(ctx context.Context, slot *models.TimeSlot) 
 
 // GetByID retrieves a time slot by ID
 func (r *TimeSlotRepository) GetByID(ctx context.Context, id string) (*models.TimeSlot, error) {
-	query := `SELECT id, owner_id, start_time, end_time, is_available, created_at FROM time_slots WHERE id = $1`
+	query := `SELECT id, owner_id, COALESCE(event_type_id::text, ''), start_time, end_time, is_available, created_at FROM time_slots WHERE id = $1`
 
 	slot := &models.TimeSlot{}
 	err := db.Pool.QueryRow(ctx, query, id).Scan(
-		&slot.ID, &slot.OwnerID, &slot.StartTime, &slot.EndTime, &slot.IsAvailable, &slot.CreatedAt,
+		&slot.ID, &slot.OwnerID, &slot.EventTypeID, &slot.StartTime, &slot.EndTime, &slot.IsAvailable, &slot.CreatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -60,18 +60,25 @@ func (r *TimeSlotRepository) GetByID(ctx context.Context, id string) (*models.Ti
 }
 
 // List retrieves a paginated list of time slots with filters
-func (r *TimeSlotRepository) List(ctx context.Context, eventTypeID string, page, pageSize int, available *bool, startTime, endTime *time.Time) ([]models.TimeSlot, int, error) {
+func (r *TimeSlotRepository) List(ctx context.Context, ownerID, eventTypeID string, page, pageSize int, available *bool, startTime, endTime *time.Time) ([]models.TimeSlot, int, error) {
 	offset := (page - 1) * pageSize
 
 	// Build query dynamically based on filters
-	query := `SELECT id, owner_id, start_time, end_time, is_available, created_at FROM time_slots WHERE 1=1`
+	query := `SELECT id, owner_id, COALESCE(event_type_id::text, ''), start_time, end_time, is_available, created_at FROM time_slots WHERE 1=1`
 	countQuery := `SELECT COUNT(*) FROM time_slots WHERE 1=1`
 	args := []interface{}{}
 	argIdx := 1
 
-	if eventTypeID != "" {
+	if ownerID != "" {
 		query += fmt.Sprintf(" AND owner_id = $%d", argIdx)
 		countQuery += fmt.Sprintf(" AND owner_id = $%d", argIdx)
+		args = append(args, ownerID)
+		argIdx++
+	}
+
+	if eventTypeID != "" {
+		query += fmt.Sprintf(" AND event_type_id = $%d", argIdx)
+		countQuery += fmt.Sprintf(" AND event_type_id = $%d", argIdx)
 		args = append(args, eventTypeID)
 		argIdx++
 	}
@@ -117,7 +124,7 @@ func (r *TimeSlotRepository) List(ctx context.Context, eventTypeID string, page,
 	var slots []models.TimeSlot
 	for rows.Next() {
 		var slot models.TimeSlot
-		err := rows.Scan(&slot.ID, &slot.OwnerID, &slot.StartTime, &slot.EndTime, &slot.IsAvailable, &slot.CreatedAt)
+		err := rows.Scan(&slot.ID, &slot.OwnerID, &slot.EventTypeID, &slot.StartTime, &slot.EndTime, &slot.IsAvailable, &slot.CreatedAt)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to scan time slot: %w", err)
 		}
@@ -134,7 +141,7 @@ func (r *TimeSlotRepository) List(ctx context.Context, eventTypeID string, page,
 // GetAvailableSlots retrieves available slots for an event type
 func (r *TimeSlotRepository) GetAvailableSlots(ctx context.Context, eventTypeID string, page, pageSize int, startTime, endTime *time.Time) ([]models.TimeSlot, int, error) {
 	available := true
-	return r.List(ctx, eventTypeID, page, pageSize, &available, startTime, endTime)
+	return r.List(ctx, eventTypeID, "", page, pageSize, &available, startTime, endTime)
 }
 
 // MarkAsUnavailable marks a slot as unavailable (booked)

--- a/backend/internal/services/booking_service.go
+++ b/backend/internal/services/booking_service.go
@@ -99,7 +99,7 @@ func (s *BookingService) GetByID(ctx context.Context, id string) (*models.Bookin
 }
 
 // List retrieves a paginated list of bookings
-func (s *BookingService) List(ctx context.Context, page, pageSize int, sortBy, sortOrder string, status *string) (*models.PaginatedResponse[models.Booking], error) {
+func (s *BookingService) List(ctx context.Context, page, pageSize int, sortBy, sortOrder string, dateFrom, dateTo *time.Time) (*models.PaginatedResponse[models.Booking], error) {
 	if page < 1 {
 		page = 1
 	}
@@ -107,7 +107,7 @@ func (s *BookingService) List(ctx context.Context, page, pageSize int, sortBy, s
 		pageSize = 20
 	}
 
-	items, totalItems, err := s.repo.List(ctx, page, pageSize, sortBy, sortOrder, status)
+	items, totalItems, err := s.repo.List(ctx, page, pageSize, sortBy, sortOrder, dateFrom, dateTo)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/services/booking_service_test.go
+++ b/backend/internal/services/booking_service_test.go
@@ -276,10 +276,10 @@ func TestBookingService_List_Success(t *testing.T) {
 		{ID: "2", GuestName: "Jane"},
 	}
 
-	mockBookingRepo.On("List", mock.Anything, 1, 20, "created_at", "desc", (*string)(nil)).
+	mockBookingRepo.On("List", mock.Anything, 1, 20, "created_at", "desc", (*time.Time)(nil), (*time.Time)(nil)).
 		Return(bookings, 2, nil)
 
-	result, err := service.List(context.Background(), 1, 20, "created_at", "desc", nil)
+	result, err := service.List(context.Background(), 1, 20, "created_at", "desc", nil, nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -297,11 +297,11 @@ func TestBookingService_List_DefaultPagination(t *testing.T) {
 	service := NewBookingService(mockBookingRepo, mockSlotRepo, mockEtRepo)
 
 	// Service passes empty strings for sortBy/sortOrder when not provided - repository sets defaults
-	mockBookingRepo.On("List", mock.Anything, 1, 20, "", "", (*string)(nil)).
+	mockBookingRepo.On("List", mock.Anything, 1, 20, "", "", (*time.Time)(nil), (*time.Time)(nil)).
 		Return([]models.Booking{}, 0, nil)
 
 	// Test with invalid page and pageSize
-	result, err := service.List(context.Background(), 0, 0, "", "", nil)
+	result, err := service.List(context.Background(), 0, 0, "", "", nil, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)
@@ -392,19 +392,19 @@ func TestBookingService_Create_NoSlotID(t *testing.T) {
 	assert.Contains(t, err.Error(), "slot ID is required")
 }
 
-// Table-driven test for CalculatePagination (already tested in owner_service_test.go)
-func TestBookingService_List_WithStatusFilter(t *testing.T) {
+func TestBookingService_List_WithDateFilters(t *testing.T) {
 	mockBookingRepo := new(MockBookingRepository)
 	mockSlotRepo := new(MockTimeSlotRepository)
 	mockEtRepo := new(MockEventTypeRepository)
 
 	service := NewBookingService(mockBookingRepo, mockSlotRepo, mockEtRepo)
 
-	status := "confirmed"
-	mockBookingRepo.On("List", mock.Anything, 1, 20, "created_at", "desc", &status).
+	dateFrom := time.Now().Add(-time.Hour)
+	dateTo := time.Now().Add(time.Hour)
+	mockBookingRepo.On("List", mock.Anything, 1, 20, "created_at", "desc", &dateFrom, &dateTo).
 		Return([]models.Booking{}, 0, nil)
 
-	result, err := service.List(context.Background(), 1, 20, "created_at", "desc", &status)
+	result, err := service.List(context.Background(), 1, 20, "created_at", "desc", &dateFrom, &dateTo)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -11,7 +11,7 @@ import (
 type BookingRepository interface {
 	Create(ctx context.Context, booking *models.Booking) error
 	GetByID(ctx context.Context, id string) (*models.Booking, error)
-	List(ctx context.Context, page, pageSize int, sortBy, sortOrder string, status *string) ([]models.Booking, int, error)
+	List(ctx context.Context, page, pageSize int, sortBy, sortOrder string, dateFrom, dateTo *time.Time) ([]models.Booking, int, error)
 	CheckOverlap(ctx context.Context, startTime, endTime time.Time) (bool, error)
 	Cancel(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
@@ -21,7 +21,7 @@ type BookingRepository interface {
 type TimeSlotRepository interface {
 	Create(ctx context.Context, slot *models.TimeSlot) error
 	GetByID(ctx context.Context, id string) (*models.TimeSlot, error)
-	List(ctx context.Context, ownerID string, page, pageSize int, available *bool, startTime, endTime *time.Time) ([]models.TimeSlot, int, error)
+	List(ctx context.Context, ownerID, eventTypeID string, page, pageSize int, available *bool, startTime, endTime *time.Time) ([]models.TimeSlot, int, error)
 	GetAvailableSlots(ctx context.Context, ownerID string, page, pageSize int, startTime, endTime *time.Time) ([]models.TimeSlot, int, error)
 	MarkAsUnavailable(ctx context.Context, slotID string) error
 }

--- a/backend/internal/services/mocks_test.go
+++ b/backend/internal/services/mocks_test.go
@@ -26,8 +26,8 @@ func (m *MockBookingRepository) GetByID(ctx context.Context, id string) (*models
 	return args.Get(0).(*models.Booking), args.Error(1)
 }
 
-func (m *MockBookingRepository) List(ctx context.Context, page, pageSize int, sortBy, sortOrder string, status *string) ([]models.Booking, int, error) {
-	args := m.Called(ctx, page, pageSize, sortBy, sortOrder, status)
+func (m *MockBookingRepository) List(ctx context.Context, page, pageSize int, sortBy, sortOrder string, dateFrom, dateTo *time.Time) ([]models.Booking, int, error) {
+	args := m.Called(ctx, page, pageSize, sortBy, sortOrder, dateFrom, dateTo)
 	if args.Get(0) == nil {
 		return nil, args.Int(1), args.Error(2)
 	}
@@ -67,8 +67,8 @@ func (m *MockTimeSlotRepository) GetByID(ctx context.Context, id string) (*model
 	return args.Get(0).(*models.TimeSlot), args.Error(1)
 }
 
-func (m *MockTimeSlotRepository) List(ctx context.Context, ownerID string, page, pageSize int, available *bool, startTime, endTime *time.Time) ([]models.TimeSlot, int, error) {
-	args := m.Called(ctx, ownerID, page, pageSize, available, startTime, endTime)
+func (m *MockTimeSlotRepository) List(ctx context.Context, ownerID, eventTypeID string, page, pageSize int, available *bool, startTime, endTime *time.Time) ([]models.TimeSlot, int, error) {
+	args := m.Called(ctx, ownerID, eventTypeID, page, pageSize, available, startTime, endTime)
 	if args.Get(0) == nil {
 		return nil, args.Int(1), args.Error(2)
 	}

--- a/backend/internal/services/time_slot_service.go
+++ b/backend/internal/services/time_slot_service.go
@@ -13,14 +13,16 @@ type TimeSlotService struct {
 	repo       TimeSlotRepository
 	configRepo SlotGenerationConfigRepository
 	ownerRepo  OwnerRepository
+	etRepo     EventTypeRepository
 }
 
 // NewTimeSlotService creates a new time slot service
-func NewTimeSlotService(repo TimeSlotRepository, configRepo SlotGenerationConfigRepository, ownerRepo OwnerRepository) *TimeSlotService {
+func NewTimeSlotService(repo TimeSlotRepository, configRepo SlotGenerationConfigRepository, ownerRepo OwnerRepository, etRepo EventTypeRepository) *TimeSlotService {
 	return &TimeSlotService{
 		repo:       repo,
 		configRepo: configRepo,
 		ownerRepo:  ownerRepo,
+		etRepo:     etRepo,
 	}
 }
 
@@ -35,15 +37,20 @@ func (s *TimeSlotService) GetByID(ctx context.Context, id string) (*models.TimeS
 }
 
 // List retrieves a paginated list of time slots
-func (s *TimeSlotService) List(ctx context.Context, ownerID string, page, pageSize int, available *bool, startTime, endTime *time.Time) (*models.PaginatedResponse[models.TimeSlot], error) {
+func (s *TimeSlotService) List(ctx context.Context, ownerID, eventTypeID string, page, pageSize int, available *bool, startTime, endTime *time.Time) (*models.PaginatedResponse[models.TimeSlot], error) {
 	if page < 1 {
 		page = 1
 	}
 	if pageSize < 1 || pageSize > 100 {
 		pageSize = 20
 	}
+	if eventTypeID != "" {
+		if _, err := s.etRepo.GetByID(ctx, eventTypeID); err != nil {
+			return nil, fmt.Errorf("event type not found: %w", err)
+		}
+	}
 
-	items, totalItems, err := s.repo.List(ctx, ownerID, page, pageSize, available, startTime, endTime)
+	items, totalItems, err := s.repo.List(ctx, ownerID, eventTypeID, page, pageSize, available, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}
@@ -90,41 +97,60 @@ func (s *TimeSlotService) GetAvailableSlots(ctx context.Context, ownerID string,
 }
 
 // GenerateSlots auto-generates time slots based on configuration
-func (s *TimeSlotService) GenerateSlots(ctx context.Context, ownerID string, req models.SlotGenerationRequest) (*models.SlotGenerationResult, error) {
+func (s *TimeSlotService) GenerateSlots(ctx context.Context, ownerID, eventTypeID string, req models.SlotGenerationRequest) (*models.SlotGenerationResult, error) {
+	eventType, err := s.etRepo.GetByID(ctx, eventTypeID)
+	if err != nil {
+		return nil, fmt.Errorf("event type not found: %w", err)
+	}
+
 	// Always use owner's timezone from database for consistency
 	owner, err := s.ownerRepo.GetByID(ctx, ownerID)
 	if err != nil {
 		return nil, fmt.Errorf("owner not found: %w", err)
 	}
 
+	timezoneName := owner.Timezone
+	if req.Timezone != nil && *req.Timezone != "" {
+		timezoneName = *req.Timezone
+	}
+
 	loc := time.UTC
-	if owner.Timezone != "" {
-		if l, err := time.LoadLocation(owner.Timezone); err == nil {
+	if timezoneName != "" {
+		if l, err := time.LoadLocation(timezoneName); err == nil {
 			loc = l
-			fmt.Printf("Using owner timezone: %s\n", owner.Timezone)
+			fmt.Printf("Using timezone: %s\n", timezoneName)
 		} else {
-			fmt.Printf("Failed to load timezone %s: %v, falling back to UTC\n", owner.Timezone, err)
+			fmt.Printf("Failed to load timezone %s: %v, falling back to UTC\n", timezoneName, err)
 		}
 	} else {
-		fmt.Println("Owner has no timezone, using UTC")
+		fmt.Println("No timezone configured, using UTC")
 	}
 	// Parse dates
-	dateFrom := time.Now().AddDate(0, 0, 1) // tomorrow
+	nowInLocation := time.Now().In(loc)
+	dateFrom := time.Date(nowInLocation.Year(), nowInLocation.Month(), nowInLocation.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, 1)
 	if req.DateFrom != "" {
 		var err error
-		dateFrom, err = time.Parse("2006-01-02", req.DateFrom)
+		parsed, err := time.ParseInLocation("2006-01-02", req.DateFrom, loc)
 		if err != nil {
 			return nil, fmt.Errorf("invalid date_from format: %w", err)
+		}
+		if parsed.Before(dateFrom) {
+			dateFrom = dateFrom
+		} else {
+			dateFrom = parsed
 		}
 	}
 
 	dateTo := dateFrom.AddDate(0, 0, 30)
 	if req.DateTo != "" {
 		var err error
-		dateTo, err = time.Parse("2006-01-02", req.DateTo)
+		dateTo, err = time.ParseInLocation("2006-01-02", req.DateTo, loc)
 		if err != nil {
 			return nil, fmt.Errorf("invalid date_to format: %w", err)
 		}
+	}
+	if dateTo.Before(dateFrom) {
+		return nil, fmt.Errorf("date_to must not be before date_from")
 	}
 
 	// Parse working hours
@@ -138,9 +164,19 @@ func (s *TimeSlotService) GenerateSlots(ctx context.Context, ownerID string, req
 		return nil, fmt.Errorf("invalid working_hours_end format: %w", err)
 	}
 
+	intervalMinutes := req.IntervalMinutes
+	if intervalMinutes == 0 {
+		intervalMinutes = 30
+	}
+
+	daysOfWeek := req.DaysOfWeek
+	if len(daysOfWeek) == 0 {
+		daysOfWeek = []int{1, 2, 3, 4, 5}
+	}
+
 	// Create days of week map
 	daysMap := make(map[int]bool)
-	for _, day := range req.DaysOfWeek {
+	for _, day := range daysOfWeek {
 		daysMap[day] = true
 	}
 
@@ -149,13 +185,15 @@ func (s *TimeSlotService) GenerateSlots(ctx context.Context, ownerID string, req
 		OwnerID:           ownerID,
 		WorkingHoursStart: req.WorkingHoursStart,
 		WorkingHoursEnd:   req.WorkingHoursEnd,
-		IntervalMinutes:   req.IntervalMinutes,
-		DaysOfWeek:        req.DaysOfWeek,
+		IntervalMinutes:   intervalMinutes,
+		DaysOfWeek:        daysOfWeek,
 		DateFrom:          dateFrom,
 		DateTo:            dateTo,
 	}
 	if req.Timezone != nil {
 		config.Timezone = *req.Timezone
+	} else {
+		config.Timezone = timezoneName
 	}
 
 	if err := s.configRepo.Create(ctx, config); err != nil {
@@ -163,21 +201,22 @@ func (s *TimeSlotService) GenerateSlots(ctx context.Context, ownerID string, req
 	}
 
 	slotsCreated := 0
-	var createdSlotIDs []string
+	slotsSkipped := 0
+	existingSlots, _, err := s.repo.List(ctx, ownerID, eventTypeID, 1, 100000, nil, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load existing slots: %w", err)
+	}
+	existing := make(map[string]struct{}, len(existingSlots))
+	for _, slot := range existingSlots {
+		existing[slot.StartTime.UTC().Format(time.RFC3339)+"|"+slot.EndTime.UTC().Format(time.RFC3339)] = struct{}{}
+	}
 
 	// Calculate slots for each day
 	currentDate := dateFrom
 	for !currentDate.After(dateTo) {
-		// Check if this day is in the days of week
-		// Go's Weekday: Sunday=0, Monday=1, ..., Saturday=6
-		// ISO: Monday=1, ..., Sunday=7
-		goWeekday := int(currentDate.Weekday())
-		isoWeekday := goWeekday
-		if goWeekday == 0 {
-			isoWeekday = 7 // Sunday
-		}
+		weekday := int(currentDate.Weekday())
 
-		if daysMap[isoWeekday] {
+		if daysMap[weekday] {
 			// Generate slots for this day in the OWNER'S timezone
 			slotStart := time.Date(currentDate.Year(), currentDate.Month(), currentDate.Day(),
 				workStart.Hour(), workStart.Minute(), 0, 0, loc)
@@ -186,15 +225,23 @@ func (s *TimeSlotService) GenerateSlots(ctx context.Context, ownerID string, req
 				workEnd.Hour(), workEnd.Minute(), 0, 0, loc)
 
 			for slotStart.Before(dayEnd) {
-				slotEnd := slotStart.Add(time.Duration(req.IntervalMinutes) * time.Minute)
+				slotEnd := slotStart.Add(time.Duration(eventType.DurationMinutes) * time.Minute)
 
 				if slotEnd.After(dayEnd) {
 					break
 				}
 
+				key := slotStart.UTC().Format(time.RFC3339) + "|" + slotEnd.UTC().Format(time.RFC3339)
+				if _, exists := existing[key]; exists {
+					slotsSkipped++
+					slotStart = slotStart.Add(time.Duration(intervalMinutes) * time.Minute)
+					continue
+				}
+
 				// Create the slot in the database (times are automatically converted to UTC)
 				slot := &models.TimeSlot{
 					OwnerID:     ownerID,
+					EventTypeID: eventTypeID,
 					StartTime:   slotStart.UTC(),
 					EndTime:     slotEnd.UTC(),
 					IsAvailable: true,
@@ -204,10 +251,10 @@ func (s *TimeSlotService) GenerateSlots(ctx context.Context, ownerID string, req
 					return nil, fmt.Errorf("failed to create slot at %s: %w", slotStart.Format(time.RFC3339), err)
 				}
 
-				createdSlotIDs = append(createdSlotIDs, slot.ID)
+				existing[key] = struct{}{}
 				slotsCreated++
 
-				slotStart = slotEnd
+				slotStart = slotStart.Add(time.Duration(intervalMinutes) * time.Minute)
 			}
 		}
 
@@ -215,7 +262,9 @@ func (s *TimeSlotService) GenerateSlots(ctx context.Context, ownerID string, req
 	}
 
 	return &models.SlotGenerationResult{
-		SlotsCreated:   slotsCreated,
-		CreatedSlotIDs: createdSlotIDs,
+		SlotsCreated: slotsCreated,
+		SlotsSkipped: slotsSkipped,
+		DateFrom:     dateFrom.Format("2006-01-02"),
+		DateTo:       dateTo.Format("2006-01-02"),
 	}, nil
 }

--- a/backend/internal/services/time_slot_service_test.go
+++ b/backend/internal/services/time_slot_service_test.go
@@ -16,8 +16,9 @@ func TestTimeSlotService_Create_Success(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	slot := &models.TimeSlot{
 		ID:          "test-slot-id",
@@ -39,8 +40,9 @@ func TestTimeSlotService_Create_Error(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	slot := &models.TimeSlot{
 		ID: "test-slot-id",
@@ -58,8 +60,9 @@ func TestTimeSlotService_GetByID_Success(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	slotID := "test-slot-id"
 	expected := &models.TimeSlot{
@@ -82,8 +85,9 @@ func TestTimeSlotService_GetByID_NotFound(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	mockRepo.On("GetByID", mock.Anything, "non-existent").Return(nil, errors.New("not found"))
 
@@ -97,8 +101,9 @@ func TestTimeSlotService_List_Success(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	ownerID := "test-owner-id"
 	slots := []models.TimeSlot{
@@ -106,10 +111,10 @@ func TestTimeSlotService_List_Success(t *testing.T) {
 		{ID: "2", OwnerID: ownerID, IsAvailable: false},
 	}
 
-	mockRepo.On("List", mock.Anything, ownerID, 1, 20, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil)).
+	mockRepo.On("List", mock.Anything, ownerID, "", 1, 20, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil)).
 		Return(slots, 2, nil)
 
-	result, err := service.List(context.Background(), ownerID, 1, 20, nil, nil, nil)
+	result, err := service.List(context.Background(), ownerID, "", 1, 20, nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.Len(t, result.Items, 2)
@@ -121,36 +126,38 @@ func TestTimeSlotService_List_DefaultPagination(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	ownerID := "test-owner-id"
-	mockRepo.On("List", mock.Anything, ownerID, 1, 20, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil)).
+	mockRepo.On("List", mock.Anything, ownerID, "", 1, 20, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil)).
 		Return([]models.TimeSlot{}, 0, nil)
 
-	result, err := service.List(context.Background(), ownerID, 0, 0, nil, nil, nil)
+	result, err := service.List(context.Background(), ownerID, "", 0, 0, nil, nil, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)
-	mockRepo.AssertCalled(t, "List", mock.Anything, ownerID, 1, 20, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil))
+	mockRepo.AssertCalled(t, "List", mock.Anything, ownerID, "", 1, 20, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil))
 }
 
 func TestTimeSlotService_List_WithFilters(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	ownerID := "test-owner-id"
 	available := true
 	startTime := time.Now()
 	endTime := time.Now().Add(24 * time.Hour)
 
-	mockRepo.On("List", mock.Anything, ownerID, 1, 20, &available, &startTime, &endTime).
+	mockRepo.On("List", mock.Anything, ownerID, "", 1, 20, &available, &startTime, &endTime).
 		Return([]models.TimeSlot{}, 0, nil)
 
-	result, err := service.List(context.Background(), ownerID, 1, 20, &available, &startTime, &endTime)
+	result, err := service.List(context.Background(), ownerID, "", 1, 20, &available, &startTime, &endTime)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)
@@ -161,8 +168,9 @@ func TestTimeSlotService_GetAvailableSlots_Success(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	ownerID := "test-owner-id"
 	futureTime := time.Now().Add(24 * time.Hour)
@@ -185,8 +193,9 @@ func TestTimeSlotService_GetAvailableSlots_FiltersPastSlots(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	ownerID := "test-owner-id"
 	pastTime := time.Now().Add(-1 * time.Hour)
@@ -213,8 +222,9 @@ func TestTimeSlotService_GetAvailableSlots_EmptyList(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	ownerID := "test-owner-id"
 	mockRepo.On("GetAvailableSlots", mock.Anything, ownerID, 1, 20, (*time.Time)(nil), (*time.Time)(nil)).
@@ -231,15 +241,129 @@ func TestTimeSlotService_List_Error(t *testing.T) {
 	mockRepo := new(MockTimeSlotRepository)
 	mockConfigRepo := new(MockSlotGenerationConfigRepository)
 	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
 
-	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo)
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
 
 	ownerID := "test-owner-id"
-	mockRepo.On("List", mock.Anything, ownerID, 1, 20, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil)).
+	mockRepo.On("List", mock.Anything, ownerID, "", 1, 20, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil)).
 		Return(nil, 0, errors.New("database error"))
 
-	result, err := service.List(context.Background(), ownerID, 1, 20, nil, nil, nil)
+	result, err := service.List(context.Background(), ownerID, "", 1, 20, nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
+}
+
+func TestTimeSlotService_GenerateSlots_UsesEventDurationAndSkipsDuplicates(t *testing.T) {
+	mockRepo := new(MockTimeSlotRepository)
+	mockConfigRepo := new(MockSlotGenerationConfigRepository)
+	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
+
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
+
+	ownerID := "test-owner-id"
+	eventTypeID := "event-type-id"
+	req := models.SlotGenerationRequest{
+		WorkingHoursStart: "09:00",
+		WorkingHoursEnd:   "11:00",
+		IntervalMinutes:   30,
+		DaysOfWeek:        []int{1},
+		DateFrom:          "2026-04-20",
+		DateTo:            "2026-04-20",
+	}
+
+	owner := &models.Owner{ID: ownerID, Timezone: "Europe/Moscow"}
+	eventType := &models.EventType{ID: eventTypeID, DurationMinutes: 60}
+	existingStart := time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC)
+	existingEnd := existingStart.Add(time.Hour)
+	existingSlots := []models.TimeSlot{{ID: "existing", OwnerID: ownerID, StartTime: existingStart, EndTime: existingEnd, IsAvailable: true}}
+
+	mockEtRepo.On("GetByID", mock.Anything, eventTypeID).Return(eventType, nil)
+	mockOwnerRepo.On("GetByID", mock.Anything, ownerID).Return(owner, nil)
+	mockConfigRepo.On("Create", mock.Anything, mock.AnythingOfType("*models.SlotGenerationConfig")).Return(nil)
+	mockRepo.On("List", mock.Anything, ownerID, eventTypeID, 1, 100000, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil)).Return(existingSlots, 1, nil)
+	mockRepo.On("Create", mock.Anything, mock.MatchedBy(func(slot *models.TimeSlot) bool {
+		duration := slot.EndTime.Sub(slot.StartTime)
+		return slot.OwnerID == ownerID && slot.EventTypeID == eventTypeID && duration == time.Hour
+	})).Return(nil).Twice()
+
+	result, err := service.GenerateSlots(context.Background(), ownerID, eventTypeID, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 2, result.SlotsCreated)
+	assert.Equal(t, 1, result.SlotsSkipped)
+	assert.Equal(t, "2026-04-20", result.DateFrom)
+	assert.Equal(t, "2026-04-20", result.DateTo)
+	mockRepo.AssertExpectations(t)
+	mockConfigRepo.AssertExpectations(t)
+	mockOwnerRepo.AssertExpectations(t)
+	mockEtRepo.AssertExpectations(t)
+}
+
+func TestTimeSlotService_GenerateSlots_AppliesDefaultsAndSundayNumbering(t *testing.T) {
+	mockRepo := new(MockTimeSlotRepository)
+	mockConfigRepo := new(MockSlotGenerationConfigRepository)
+	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
+
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
+
+	ownerID := "test-owner-id"
+	eventTypeID := "event-type-id"
+	req := models.SlotGenerationRequest{
+		WorkingHoursStart: "09:00",
+		WorkingHoursEnd:   "10:00",
+		DateFrom:          "2026-04-19",
+		DateTo:            "2026-04-19",
+		DaysOfWeek:        []int{0},
+	}
+
+	owner := &models.Owner{ID: ownerID, Timezone: "UTC"}
+	eventType := &models.EventType{ID: eventTypeID, DurationMinutes: 30}
+
+	mockEtRepo.On("GetByID", mock.Anything, eventTypeID).Return(eventType, nil)
+	mockOwnerRepo.On("GetByID", mock.Anything, ownerID).Return(owner, nil)
+	mockConfigRepo.On("Create", mock.Anything, mock.MatchedBy(func(config *models.SlotGenerationConfig) bool {
+		return config.IntervalMinutes == 30 && len(config.DaysOfWeek) == 1 && config.DaysOfWeek[0] == 0 && config.Timezone == "UTC"
+	})).Return(nil)
+	mockRepo.On("List", mock.Anything, ownerID, eventTypeID, 1, 100000, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil)).Return([]models.TimeSlot{}, 0, nil)
+	mockRepo.On("Create", mock.Anything, mock.MatchedBy(func(slot *models.TimeSlot) bool {
+		return slot.EventTypeID == eventTypeID
+	})).Return(nil).Twice()
+
+	result, err := service.GenerateSlots(context.Background(), ownerID, eventTypeID, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 2, result.SlotsCreated)
+	assert.Equal(t, 0, result.SlotsSkipped)
+	mockRepo.AssertExpectations(t)
+	mockConfigRepo.AssertExpectations(t)
+	mockOwnerRepo.AssertExpectations(t)
+	mockEtRepo.AssertExpectations(t)
+}
+
+func TestTimeSlotService_List_WithEventTypeFilter(t *testing.T) {
+	mockRepo := new(MockTimeSlotRepository)
+	mockConfigRepo := new(MockSlotGenerationConfigRepository)
+	mockOwnerRepo := new(MockOwnerRepository)
+	mockEtRepo := new(MockEventTypeRepository)
+
+	service := NewTimeSlotService(mockRepo, mockConfigRepo, mockOwnerRepo, mockEtRepo)
+
+	ownerID := "test-owner-id"
+	eventTypeID := "event-type-id"
+	mockEtRepo.On("GetByID", mock.Anything, eventTypeID).Return(&models.EventType{ID: eventTypeID}, nil)
+	mockRepo.On("List", mock.Anything, ownerID, eventTypeID, 1, 20, (*bool)(nil), (*time.Time)(nil), (*time.Time)(nil)).Return([]models.TimeSlot{}, 0, nil)
+
+	result, err := service.List(context.Background(), ownerID, eventTypeID, 1, 20, nil, nil, nil)
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Items, 0)
+	mockRepo.AssertExpectations(t)
+	mockEtRepo.AssertExpectations(t)
 }

--- a/backend/migrations/003_restore_event_type_id_to_time_slots.up.sql
+++ b/backend/migrations/003_restore_event_type_id_to_time_slots.up.sql
@@ -1,0 +1,14 @@
+-- Migration: 003_restore_event_type_id_to_time_slots.up.sql
+-- Restore event_type_id on time_slots so owner slot filtering can follow the TypeSpec contract.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'time_slots' AND column_name = 'event_type_id'
+    ) THEN
+        ALTER TABLE time_slots ADD COLUMN event_type_id UUID REFERENCES event_types(id) ON DELETE CASCADE;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_time_slots_event_type_id ON time_slots(event_type_id);


### PR DESCRIPTION
## Summary
- align the Go backend routes and payload behavior with the TypeSpec contract for issue #3
- make slot generation event-type aware, restore `event_type_id` storage for owner slot filtering, and persist the matching migration
- update backend booking and slot tests to cover the new filters, defaults, validation, and conflict handling